### PR TITLE
replace use of deprecated method

### DIFF
--- a/src/HandlebarsHelper.php
+++ b/src/HandlebarsHelper.php
@@ -19,7 +19,7 @@ class HandlebarsHelper
         // I'm relaxing the argument type above, but doing the check here to
         // determine the helper's invocation method
 
-        if (is_a($helper, 'JaySDe\HandlebarsBundle\Helper\HelperInterface')) {
+        if ($helper instanceof HelperInterface) {
             $method = 'handle';
         } else {
             $method = 'execute';


### PR DESCRIPTION
is_a has been deprecated in favour of instanceof
